### PR TITLE
Fix for install with rvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ cd ext
 ruby extconf.rb
 make
 make install # Creates ../lib/ruby/site_ruby/X.X.X/<arch>/tf/Tensorflow.bundle (.so Linux)
+             # Creates ${GEM_HOME}/gems/tensorflow-0.0.1/lib/tf/Tensorflow.bundle (.so with rvm)
 cd ./..
 bundle exec rake install
 ```

--- a/lib/tensorflow.rb
+++ b/lib/tensorflow.rb
@@ -1,6 +1,10 @@
 require 'tensorflow/core/framework/tensor'
 require 'tensorflow/core/framework/graph'
-require 'tf/Tensorflow'
+if ENV['rvm_version'].nil?
+  require 'tf/Tensorflow'
+else
+  require "#{ENV['GEM_HOME']}/gems/tensorflow-0.0.1/lib/tf/Tensorflow"
+end
 require 'tensor'
 require 'graph'
 require 'session'


### PR DESCRIPTION
When installing using rvm, the path where Tensorflow.bundle installed is different.
This has 2 repercussions:
* The note in README.md specifying the location of Tensorflow.bundle is wrong
* The `require 'tf/Tensorflow` in `lib/tensorflow.rb` fails.
This is an attempt to fix this issue. Please advise how to improve.